### PR TITLE
more error handling

### DIFF
--- a/tk/basewidget.go
+++ b/tk/basewidget.go
@@ -3,6 +3,7 @@
 package tk
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -73,12 +74,21 @@ func (w *BaseWidget) DestroyChildren() error {
 
 func (w *BaseWidget) NativeAttribute(key string) string {
 	if !IsValidWidget(w) {
+		if fnErrorHandle != nil {
+			dumpError(fmt.Errorf("invalid widget: %s", w))
+		}
 		return ""
 	}
 	if !w.info.MetaClass.HasAttribute(key) {
+		if fnErrorHandle != nil {
+			dumpError(errors.New("no such attribute: " + key))
+		}
 		return ""
 	}
-	r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+	r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+	if err != nil {
+		dumpError(err)
+	}
 	return r
 }
 
@@ -88,13 +98,19 @@ func (w *BaseWidget) NativeAttributes(keys ...string) (attributes []NativeAttr) 
 	}
 	if keys == nil {
 		for _, key := range w.info.MetaClass.Attributes {
-			r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+			r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+			if err != nil {
+				dumpError(err)
+			}
 			attributes = append(attributes, NativeAttr{key, r})
 		}
 	} else {
 		for _, key := range keys {
 			if w.info.MetaClass.HasAttribute(key) {
-				r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+				r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
+				if err != nil {
+					dumpError(err)
+				}
 				attributes = append(attributes, NativeAttr{key, r})
 			}
 		}

--- a/tk/basewidget.go
+++ b/tk/basewidget.go
@@ -74,15 +74,11 @@ func (w *BaseWidget) DestroyChildren() error {
 
 func (w *BaseWidget) NativeAttribute(key string) string {
 	if !IsValidWidget(w) {
-		if fnErrorHandle != nil {
-			dumpError(fmt.Errorf("invalid widget: %s", w))
-		}
+		dumpError(fmt.Errorf("invalid widget: %s", w))
 		return ""
 	}
 	if !w.info.MetaClass.HasAttribute(key) {
-		if fnErrorHandle != nil {
-			dumpError(errors.New("no such attribute: " + key))
-		}
+		dumpError(errors.New("no such attribute: " + key))
 		return ""
 	}
 	r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))

--- a/tk/basewidget.go
+++ b/tk/basewidget.go
@@ -81,10 +81,7 @@ func (w *BaseWidget) NativeAttribute(key string) string {
 		dumpError(errors.New("no such attribute: " + key))
 		return ""
 	}
-	r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
-	if err != nil {
-		dumpError(err)
-	}
+	r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
 	return r
 }
 
@@ -94,19 +91,13 @@ func (w *BaseWidget) NativeAttributes(keys ...string) (attributes []NativeAttr) 
 	}
 	if keys == nil {
 		for _, key := range w.info.MetaClass.Attributes {
-			r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
-			if err != nil {
-				dumpError(err)
-			}
+			r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
 			attributes = append(attributes, NativeAttr{key, r})
 		}
 	} else {
 		for _, key := range keys {
 			if w.info.MetaClass.HasAttribute(key) {
-				r, err := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
-				if err != nil {
-					dumpError(err)
-				}
+				r, _ := evalAsString(fmt.Sprintf("%v cget -%v", w.id, key))
 				attributes = append(attributes, NativeAttr{key, r})
 			}
 		}

--- a/tk/event.go
+++ b/tk/event.go
@@ -131,10 +131,7 @@ func (e *Event) toInt64(s string) int64 {
 }
 
 func (e *Event) toBool(s string) bool {
-	if s == "1" {
-		return true
-	}
-	return false
+	return s == "1"
 }
 
 func (e *Event) toString(s string) string {
@@ -191,7 +188,7 @@ func (e *KeyEvent) removeModifier(sym string, name string, mod KeyModifier) {
 	}
 }
 
-//TODO: almost check key modifier
+// TODO: almost check key modifier
 func BindKeyEventEx(tag string, fnPress func(e *KeyEvent), fnRelease func(e *KeyEvent)) error {
 	var ke KeyEvent
 	var err error
@@ -275,10 +272,10 @@ func BindInfo(tag string) []string {
 	return v
 }
 
-//Associates the virtual event virtual with the physical event sequence(s)
-//given by the sequence arguments, so that the virtual event will trigger
-//whenever any one of the sequences occurs. Virtual may be any string value
-//and sequence may have any of the values allowed for the sequence argument
+// Associates the virtual event virtual with the physical event sequence(s)
+// given by the sequence arguments, so that the virtual event will trigger
+// whenever any one of the sequences occurs. Virtual may be any string value
+// and sequence may have any of the values allowed for the sequence argument
 // to the bind command. If virtual is already defined, the new physical event
 // sequences add to the existing sequences for the event.
 func AddVirtualEventPhysicalEvent(virtual string, event string, events ...string) error {
@@ -289,11 +286,11 @@ func AddVirtualEventPhysicalEvent(virtual string, event string, events ...string
 	return eval(fmt.Sprintf("event add %v %v", virtual, strings.Join(eventList, " ")))
 }
 
-//Deletes each of the sequences from those associated with the virtual event
+// Deletes each of the sequences from those associated with the virtual event
 // given by virtual. Virtual may be any string value and sequence may have
-//any of the values allowed for the sequence argument to the bind command.
-//Any sequences not currently associated with virtual are ignored.
-//If no sequence argument is provided, all physical event sequences are removed
+// any of the values allowed for the sequence argument to the bind command.
+// Any sequences not currently associated with virtual are ignored.
+// If no sequence argument is provided, all physical event sequences are removed
 // for virtual, so that the virtual event will not trigger anymore.
 func RemoveVirtualEventPhysicalEvent(virtual string, events ...string) error {
 	if !IsVirtualEvent(virtual) {
@@ -310,7 +307,7 @@ func VirtualEventInfo(virtual string) []string {
 	return r
 }
 
-//TODO: event attr
+// TODO: event attr
 type EventAttr struct {
 	key   string
 	value string

--- a/tk/tk.go
+++ b/tk/tk.go
@@ -252,7 +252,7 @@ func evalAsIntListEx(script string, dump bool) ([]int, error) {
 }
 
 func dumpError(err error) {
-	if fnErrorHandle != nil {
+	if fnErrorHandle != nil && err != nil {
 		fnErrorHandle(fmt.Errorf("%v", err))
 	}
 }

--- a/tk/widget_type.go
+++ b/tk/widget_type.go
@@ -3,6 +3,7 @@
 package tk
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -70,6 +71,7 @@ func (typ WidgetType) ThemeConfigure() string {
 	_, meta, _ := typ.MetaClass(true)
 	for _, attr := range attrs {
 		if !meta.HasAttribute(attr.Key) {
+			dumpError(errors.New("no such attribute: " + attr.Key))
 			continue
 		}
 		list = append(list, fmt.Sprintf("-%v %q", attr.Key, attr.Value))
@@ -95,6 +97,7 @@ func buildWidgetAttributeScript(meta *MetaClass, ttk bool, attributes []*WidgetA
 			continue
 		}
 		if !meta.HasAttribute(attr.Key) {
+			dumpError(errors.New("no such attribute: " + attr.Key))
 			continue
 		}
 		if strs, ok := attr.Value.([]string); ok {


### PR DESCRIPTION
While developing I want my mistakes to kill the running app.

To that end I've set up a (local) error handler that panics:

```go
	tk.SetErrorHandle(core.PanicOnErr)
```

and modified some cases where errors or unknown attributes were being ignored:

* widget, base_widget, errors are now caught and sent to dumpError.
* failure to find a given attribute results in an error sent to dumpError.
* ...